### PR TITLE
in social media mode, hide .topic-details element if empty

### DIFF
--- a/assets/javascripts/discourse/initializers/preview-edits.js.es6
+++ b/assets/javascripts/discourse/initializers/preview-edits.js.es6
@@ -166,6 +166,8 @@ export default {
           this.$().addClass('social')
           this.$('.topic-intro').prependTo(this.$('.main-link'))
           this.$('.topic-title').prependTo(this.$('.main-link'))
+          if (this.$('.topic-details').children().length < 1)
+            this.$('.topic-details').hide()
         }
       },
 


### PR DESCRIPTION
A minor adjustment to hide the .topic-details element when it has no children. Because currently, it shows an unwanted space, example: https://monosnap.com/file/Y3RfNlFdjkjTkP3pOtB8lsDYFGhhFX 
