### PR TITLE
fix post_id vs post_number bug

### DIFF
--- a/assets/javascripts/discourse/initializers/preview-edits.js.es6
+++ b/assets/javascripts/discourse/initializers/preview-edits.js.es6
@@ -179,8 +179,8 @@ export default {
         this.$('.topic-excerpt').on('click.topic-excerpt', () => {
           let topic = this.get('topic'),
               url = '/t/' + topic.slug + '/' + topic.id;
-          if (topic.topic_post_id) {
-            url += '/' + topic.topic_post_id
+          if (topic.topic_post_number) {
+            url += '/' + topic.topic_post_number
           }
           DiscourseURL.routeTo(url)
         })

--- a/plugin.rb
+++ b/plugin.rb
@@ -189,7 +189,8 @@ after_initialize do
                :topic_post_can_like,
                :topic_post_can_unlike,
                :topic_post_bookmarked,
-               :topic_post_is_current_users
+               :topic_post_is_current_users,
+               :topic_post_number
 
     def include_topic_post_id?
       object.previewed_post.present?
@@ -197,6 +198,10 @@ after_initialize do
 
     def topic_post_id
       object.previewed_post&.id
+    end
+
+    def topic_post_number
+      object.previewed_post&.post_number
     end
 
     def excerpt


### PR DESCRIPTION
I observed that routing from `/t/topic_id/post_id` was always routing to the last post in the topic, not the post clicked on. So, I think there was a need to serialize the solution post's number in the topic, so now it's `/t/topic_id/post_number`.