### PR TITLE
Make icons FA5 ready

### DIFF
--- a/assets/javascripts/discourse/lib/utilities.js.es6
+++ b/assets/javascripts/discourse/lib/utilities.js.es6
@@ -1,3 +1,5 @@
+import { iconHTML } from "discourse-common/lib/icon-library";
+
 var isThumbnail = function(path) {
   return typeof path === 'string' &&
          path !== 'false' &&
@@ -76,7 +78,7 @@ var buttonHTML = function(action) {
   var html = "<button class='list-button " + action.class + "'";
   if (action.title) { html += 'title="' + I18n.t(action.title) + '"'; }
   if (action.disabled) {html += ' disabled';}
-  html += "><i class='fa fa-" + action.icon + "' aria-hidden='true'></i>";
+  html += `>${iconHTML(action.icon)}`;
   html += "</button>";
   return html;
 };

--- a/assets/javascripts/discourse/templates/list/topic-list-item.raw.hbs
+++ b/assets/javascripts/discourse/templates/list/topic-list-item.raw.hbs
@@ -68,7 +68,7 @@
     <td class="num likes">
       {{#if hasLikes}}
         <a href='{{topic.summaryUrl}}'>
-          {{number topic.like_count}} <i class='fa fa-heart'></i>
+          {{number topic.like_count}} {{d-icon 'heart'}}
         </a>
       {{/if}}
     </td>
@@ -78,7 +78,7 @@
     <td class="num likes">
       {{#if hasOpLikes}}
         <a href='{{topic.summaryUrl}}'>
-          {{number topic.op_like_count}} <i class='fa fa-heart'></i>
+          {{number topic.op_like_count}} {{d-icon 'heart'}}
         </a>
       {{/if}}
     </td>

--- a/assets/stylesheets/previews_common.scss
+++ b/assets/stylesheets/previews_common.scss
@@ -420,19 +420,19 @@ button.list-button {
   }
 
   &.bookmarked, &.topic-bookmark:hover {
-    i.fa-bookmark {
+    i.fa-bookmark, .d-icon-bookmark {
       color: $tertiary;
     }
   }
 }
 
 .user-main .list-button {
-  .fa-heart {
+  .fa-heart, .d-icon-heart {
     color: inherit !important;
   }
 
   &.has-like {
-    .fa-heart {
+    .fa-heart, .d-icon-heart {
       color: $love !important;
     }
   }

--- a/plugin.rb
+++ b/plugin.rb
@@ -9,6 +9,9 @@ register_asset 'stylesheets/previews_mobile.scss'
 register_asset 'javascripts/discourse/lib/masonry/masonry.js'
 register_asset 'javascripts/discourse/lib/imagesloaded/imagesloaded.js'
 
+register_svg_icon "bookmark" if respond_to?(:register_svg_icon)
+register_svg_icon "heart" if respond_to?(:register_svg_icon)
+
 enabled_site_setting :topic_list_previews_enabled
 
 after_initialize do


### PR DESCRIPTION
In preparation for FA5 icons in Discourse core, more details at https://meta.discourse.org/t/introducing-font-awesome-5-and-svg-icons/101643