### PR TITLE
FIX: stop overwriting manual thumbnail selections

### DIFF
--- a/lib/cooked_post_processor_edits.rb
+++ b/lib/cooked_post_processor_edits.rb
@@ -25,7 +25,7 @@ CookedPostProcessor.class_eval do
   end
 
   def update_post_image
-
+    return if !@post.topic.image_url.blank? && !@post.topic.custom_fields['thumbnail_from_post'].blank?  
     img = extract_post_image
     
     if @has_oneboxes

--- a/plugin.rb
+++ b/plugin.rb
@@ -76,8 +76,6 @@ after_initialize do
     add_to_serializer(:basic_category, key.to_sym, false) { object.custom_fields[key] }
   end
 
-  PostRevisor.track_topic_field(:image_url)
-
   PostRevisor.class_eval do
     track_topic_field(:image_url) do |tc, image_url|
       tc.record_change('image_url', tc.topic.image_url, image_url)


### PR DESCRIPTION
Post processor was deleting the manual selection, this change should resolve