### PR TITLE
FIX: Like button no longer working due to core change

### DIFF
--- a/assets/javascripts/discourse/initializers/preview-edits.js.es6
+++ b/assets/javascripts/discourse/initializers/preview-edits.js.es6
@@ -389,7 +389,7 @@ export default {
               newCount = count + (change || 0);
           this.set('hasLiked', Boolean(change > 0));
           this.set('likeDifference', newCount);
-          this.rerenderBuffer();
+          this.renderTopicListItem();
           this._afterRender();
         },
 


### PR DESCRIPTION
A recent change in Discourse core

https://github.com/discourse/discourse/commit/fc94b6cb9ee709a6744dc0da477f4a37e43d37e4

that removes the Render Buffer breaks the like button on the topic
preview. This fix uses the new method to update the topic list item if
it needs to be refreshed.