### PR TITLE
Update preview-route-edits.js.es6

### DIFF
--- a/assets/javascripts/discourse/initializers/preview-route-edits.js.es6
+++ b/assets/javascripts/discourse/initializers/preview-route-edits.js.es6
@@ -1,7 +1,7 @@
 import { featuredImagesEnabled } from '../lib/utilities';
 import { ajax } from 'discourse/lib/ajax';
 import { withPluginApi } from 'discourse/lib/plugin-api';
-import PreloadStore from "preload-store";
+import PreloadStore from "discourse/lib/preload-store";
 import CategoryList from "discourse/models/category-list";
 import TopicList from "discourse/models/topic-list";
 


### PR DESCRIPTION
preload-store is deprecated. Using discourse/lib/preload-store instead.