### PR TITLE
DEV: Cleanup draft attributes in lists

### DIFF
--- a/assets/javascripts/discourse/initializers/preview-route-edits.js.es6
+++ b/assets/javascripts/discourse/initializers/preview-route-edits.js.es6
@@ -106,10 +106,7 @@ export default {
                 ),
                 topics: TopicList.topicsFrom(this.store, topicsList),
                 can_create_category: categoriesList.can_create_category,
-                can_create_topic: categoriesList.can_create_topic,
-                draft_key: categoriesList.draft_key,
-                draft: categoriesList.draft,
-                draft_sequence: categoriesList.draft_sequence
+                can_create_topic: categoriesList.can_create_topic
               });
             }
             // Otherwise, return the ajax result
@@ -120,10 +117,7 @@ export default {
                 categories: CategoryList.categoriesFrom(this.store, result),
                 topics: TopicList.topicsFrom(this.store, result),
                 can_create_category: result.category_list.can_create_category,
-                can_create_topic: result.category_list.can_create_topic,
-                draft_key: result.category_list.draft_key,
-                draft: result.category_list.draft,
-                draft_sequence: result.category_list.draft_sequence
+                can_create_topic: result.category_list.can_create_topic
               });
             });
           });


### PR DESCRIPTION
Core no longer uses these and they will be removed via
https://github.com/discourse/discourse/pull/12525