### PR TITLE
Add deprecation notice to admin dashboard

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,4 +1,5 @@
 en:
+  topic_previews_deprecated: "The discourse-topic-previews plugin is deprecated in favour of <a href='https://thepavilion.io/t/which-one-to-install-plugin-or-tc/3996'>the equivalent theme component</a>. Remove discourse-topic-previews from your app.yml file to avoid errors."
   site_settings:
     topic_list_tiles: "Apply tiles arrangement to selected lists in this category."
     topic_list_tiles_transition_time: "Number of seconds for tiles layout transition on view change (desktop only)"

--- a/plugin.rb
+++ b/plugin.rb
@@ -19,6 +19,10 @@ enabled_site_setting :topic_list_previews_enabled
 DiscoursePluginRegistry.serialized_current_user_fields << "tlp_user_prefs_prefer_low_res_thumbnails"
 
 after_initialize do
+  AdminDashboardData.add_problem_check do
+    I18n.t("topic_previews_deprecated")
+  end
+
   User.register_custom_field_type('tlp_user_prefs_prefer_low_res_thumbnails', :boolean)
   Topic.register_custom_field_type('user_chosen_thumbnail_url', :string)
   Category.register_custom_field_type('thumbnail_width', :integer)


### PR DESCRIPTION
This should help to reduce support load

<img width="602" alt="Screenshot 2022-01-07 at 21 00 16" src="https://user-images.githubusercontent.com/6270921/148606996-99f7587a-1394-47cd-9ada-2260bb890235.png">

