### PR TITLE
FIX: Handle both old and new FileStore download API

### DIFF
--- a/lib/topic_previews/upload_extension.rb
+++ b/lib/topic_previews/upload_extension.rb
@@ -6,15 +6,16 @@ module TopicPreviews
     def calculate_dominant_color!(local_path = nil)
       color = nil
 
-      color = "" if !FileHelper.is_supported_image?("image.#{extension}") ||
-        extension == "svg"
+      color = "" if !FileHelper.is_supported_image?("image.#{extension}") || extension == "svg"
 
       if color.nil?
         local_path ||=
           if local?
             Discourse.store.path_for(self)
           else
-            Discourse.store.download_safe(self)&.path
+            result = Discourse.store.download_safe(self)
+            # TODO(zogstrip): switch to new API once https://github.com/discourse/discourse/pull/37760 is merged
+            result.is_a?(String) ? result : result&.path
           end
 
         if local_path.nil?
@@ -40,7 +41,7 @@ module TopicPreviews
                 "-format",
                 "%c",
                 "histogram:info:",
-                timeout: DOMINANT_COLOR_COMMAND_TIMEOUT_SECONDS
+                timeout: DOMINANT_COLOR_COMMAND_TIMEOUT_SECONDS,
               )
 
             # Output format:
@@ -48,9 +49,7 @@ module TopicPreviews
 
             color = data[/#([0-9A-F]{6})/, 1]
 
-            if color.nil?
-              raise "Calculated dominant color but unable to parse output:\n#{data}"
-            end
+            raise "Calculated dominant color but unable to parse output:\n#{data}" if color.nil?
 
             color
           rescue Discourse::Utils::CommandError => e


### PR DESCRIPTION
Adds compatibility layer to handle FileStore#download returning either File objects (old API) or String paths (new API). This allows the plugin to work with both versions of Discourse core during the transition period.

The change checks the result type at runtime:
- String path: use directly
- File object: extract .path attribute

See - https://github.com/discourse/discourse/pull/37760