### PR TITLE
FIX: restore theme component thumbnail generation

### DIFF
--- a/lib/topic_previews/cooked_post_processor_extension.rb
+++ b/lib/topic_previews/cooked_post_processor_extension.rb
@@ -48,7 +48,9 @@ module TopicPreviews
     end
 
     def get_extra_sizes
-      ThemeModifierHelper.new(theme_ids: Theme.user_selectable.pluck(:id)).topic_thumbnail_sizes
+      ThemeModifierHelper.new(
+        theme_ids: Theme.enabled_theme_and_component_ids,
+      ).topic_thumbnail_sizes
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # name: discourse-topic-previews-sidecar
 # about: Sidecar Plugin to support Topic List Preview Theme Component
-# version: 6.3.0
+# version: 6.3.1
 # authors: Robert Barrow, Angus McLeod
 # url: https://github.com/paviliondev/discourse-topic-previews
 

--- a/spec/lib/topic_previews/cooked_post_processor_extension_spec.rb
+++ b/spec/lib/topic_previews/cooked_post_processor_extension_spec.rb
@@ -73,4 +73,16 @@ RSpec.describe CookedPostProcessor do
     expect(post.reload.image_upload_id).to eq(manual_upload.id)
     expect(post.topic.reload.image_upload_id).to eq(manual_upload.id)
   end
+
+  it "includes enabled theme component thumbnail sizes when generating thumbnails" do
+    post = Fabricate(:post, user: user, raw: "placeholder")
+    helper = stub(topic_thumbnail_sizes: [[800, 800]])
+
+    Theme.stubs(:enabled_theme_and_component_ids).returns([12, 34])
+    ThemeModifierHelper.expects(:new).with(theme_ids: [12, 34]).returns(helper)
+
+    expect(processor_for(post, "<p><img src='#{image_upload.url}'></p>").get_extra_sizes).to eq(
+      [[800, 800]],
+    )
+  end
 end


### PR DESCRIPTION
This change restores thumbnail generation for sizes defined by enabled theme components.

  The regression was that the plugin switched to Theme.user_selectable.pluck(:id) when gathering extra thumbnail sizes,
  which excludes theme components. For sites using the Topic List Previews theme component, that meant component-defined
  sizes like [800, 800] were no longer being generated, so expected optimized derivatives such as 800x450 could be
  missing.

  The fix changes the plugin to use Theme.enabled_theme_and_component_ids instead, and bumps the plugin version from
  6.3.0 to 6.3.1. A regression spec was added to cover enabled theme/component thumbnail sizes.